### PR TITLE
Call fcopy command, instead of calling fcopy-mode directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 ## Introduction
 
-<dfn>Funny copy</dfn> is a minor mode to copy text; first, set the **paste
-point**, and next look for the text to copy.  The past point is the point where
-fcopy-mode start.  One stroke commands are provided to search and copy the text.
-Copy commands automatically back the cursor to the past point, insert the text,
-and exit fcopy-mode.
+<dfn>fcopy</dfn> starts `fcopy-mode`, a minor mode to copy text; first, set the
+**paste point**, and next look for the text to copy.  The past point is the
+point where fcopy-mode start.  One stroke commands are provided to search and
+copy the text.  Copy commands automatically back the cursor to the past point,
+insert the text, and exit fcopy-mode.
 
 ## Install fcopy
 
 Put this in your .emacs file:
 
 ```elisp
-(autoload 'fcopy-mode "fcopy" "copy lines or region without editing." t)
+(autoload 'fcopy "fcopy" "Copy lines or region without editing." t)
 ```
 
 ## Usage of fcopy
 
-<kbd>M-x fcopy-mode</kbd> takes you into Funny Copy mode.  The place where you
+<kbd>M-x fcopy</kbd> brings you into Funny Copy mode.  The place where you
 get in fcopy-mode is the paste point; the text you choose to copy will be
 inserted.
 

--- a/fcopy.el
+++ b/fcopy.el
@@ -370,6 +370,11 @@ use the function `fcopy'.")
 ;;; Commands
 
 ;;;###autoload
+(defun fcopy ()
+  "Start fcopy-mode"
+  (interactive)
+  (fcopy-mode t))
+    
 (defun fcopy-mode (&optional arg)
   "Minor mode for copying text but not editing it.
 Letters do not insert themselves.  Instead following commands are
@@ -379,8 +384,7 @@ provided.  Most commands take prefix arguments.
 
 Entry to this mode calls the value of `fcopy-mode-hook' if that value
 is non-nil."
-  (interactive "*P")
-  (if (and arg (< (prefix-numeric-value arg) 0))
+  (if (not arg)
       ;; Toggle off funny copy.
       (call-interactively 'fcopy-exit)
     ;; Toggle on funny copy.

--- a/fcopy.el
+++ b/fcopy.el
@@ -101,11 +101,11 @@
 
 ;; To install, put this in your .emacs file:
 ;;
-;;  (autoload 'fcopy-mode "fcopy" "copy lines or region without editing." t)
+;;  (autoload 'fcopy "fcopy" "copy lines or region without editing." t)
 ;;
 ;; And bind it to any key you like:
 ;;
-;;  (define-key mode-specific-map "k" 'fcopy-mode)  ; C-c k for fcopy-mode
+;;  (define-key mode-specific-map "k" 'fcopy)  ; C-c k for fcopy
 ;;
 
 ;;; Version and ChangeLog:
@@ -371,7 +371,8 @@ use the function `fcopy'.")
 
 ;;;###autoload
 (defun fcopy ()
-  "Start fcopy-mode"
+  "Copy lines or region without editing
+Start `fcopy-mode'."
   (interactive)
   (fcopy-mode t))
     


### PR DESCRIPTION
New command `fcopy` starts `fcopy-mode`.

refs. https://github.com/milkypostman/melpa/pull/2480#issuecomment-74439632
